### PR TITLE
Fixes for app ID errors and capitalisation errors

### DIFF
--- a/SteamDeckAnalyzer/sda_gameapps.py
+++ b/SteamDeckAnalyzer/sda_gameapps.py
@@ -151,12 +151,6 @@ class SteamDeckGameAppsDSIM(DataSourceIngestModulePlus):
         for appdata in sources.values():
             app_ids.update(appdata.keys())
         app_ids = sorted(app_ids, key=int)
-        
-        #app_ids.remove("1070560")
-        #app_ids.remove("1391110")
-        #app_ids.remove("1628350")
-        #app_ids.remove("2805730")
-        #app_ids.remove("228980")
 
         # prepare dictionary template for each found app
         dict_apps = {}

--- a/SteamDeckAnalyzer/sda_gameapps.py
+++ b/SteamDeckAnalyzer/sda_gameapps.py
@@ -232,7 +232,6 @@ class SteamDeckGameAppsDSIM(DataSourceIngestModulePlus):
         return filtered_files
 
     def __parse_localconfig_vdf(self, dict_localconfig):
-
         assert isinstance(dict_localconfig, OrderedDict) or isinstance(dict_localconfig, dict), \
             "{}: {}".format(type(dict_localconfig), dict_localconfig)
         assert "UserLocalConfigStore" in dict_localconfig, \
@@ -289,7 +288,6 @@ class SteamDeckGameAppsDSIM(DataSourceIngestModulePlus):
                 if appdata["autocloud_lastlaunch"] == data["LastPlayedTimesSyncTime"]:
                     sanity_check = True
                     break
-        #assert sanity_check is True            # Failing this assertion meant that no timestamps and other data was added to the table even if they were present on the disk image
 
         # summarize app IDs and app information found in localconfig.vdf
         app_ids = sorted(set(itertools.chain(


### PR DESCRIPTION
While testing the plugin on a SteamDeck image we encountered a few errors, that prevented the plugin to work correctly and find all if any games and apps. The games that were found were missing a lot of data and timestamps. One of the errors had to do with missing IDs in Steam database and another had to do with capitalization of keys in one of the functions. 

We encountered these errors while working on a paper as part of a course on my uni and we may get extra credit if this pull request gets accepted. We'd greatly appreciate if you take a look at this submission. 